### PR TITLE
1000x faster duplicate points removal

### DIFF
--- a/gcodetools-dev.py
+++ b/gcodetools-dev.py
@@ -5266,15 +5266,10 @@ class Gcodetools(inkex.Effect):
 
 
 		def remove_duplicates(points):
-			i=0		
-			out=[]
+			s = set([])
 			for p in points:
-				for j in xrange(i,len(points)):
-					if p==points[j]: points[j]=[None,None]	
-				if p!=[None,None]: out+=[p]
-			i+=1
-			return(out)
-	
+				s.add(p)
+			return list(s)
 	
 		def get_way_len(points):
 			l=0

--- a/stable/gcodetools.py
+++ b/stable/gcodetools.py
@@ -4439,15 +4439,10 @@ class Gcodetools(inkex.Effect):
 
 
 		def remove_duplicates(points):
-			i=0		
-			out=[]
+			s = set([])
 			for p in points:
-				for j in xrange(i,len(points)):
-					if p==points[j]: points[j]=[None,None]	
-				if p!=[None,None]: out+=[p]
-			i+=1
-			return(out)
-	
+				s.add(p)
+			return list(s)
 	
 		def get_way_len(points):
 			l=0


### PR DESCRIPTION
the current implementation uses an algorithm with O(n^2) time complexity which is *very* expensive in case of many points; the proposed implementation is O(n).

To give an idea: the current algorithm on a list of 10000 integers between 0 and 5000 takes around 8.7 seconds on my pc, whereas the new routine takes around 0.002 seconds (the new routine doesn't keep the original ordering of points but as far as I can tell it's not needed)
